### PR TITLE
Fix `squdo` typos in sample

### DIFF
--- a/sample/etc/sudo.prompt.pair
+++ b/sample/etc/sudo.prompt.pair
@@ -1,8 +1,8 @@
-]0;squdo: <%U@%h:%d $ > %C[8;%H;%WtYou have been asked to approve and monitor the following squdo session:
+]0;sudo: <%U@%h:%d $ > %C[8;%H;%WtYou have been asked to approve and monitor the following sudo session:
 
     <[1m[34m%U[0m@[1m[31m%h[0m:[1m[34m%d[0m [31m$[0m > %C
 
-Once approved, this terminal will mirror all output from the active squdo session until its completion.
+Once approved, this terminal will mirror all output from the active sudo session until its completion.
 
 [1mClosing this terminal, losing your network connection to this host, or explicitly ending the session by typing <Ctrl-D> will cause the command being run under elevated privileges to terminate immediately.[0m
 

--- a/sample/etc/sudo.prompt.user
+++ b/sample/etc/sudo.prompt.user
@@ -1,4 +1,4 @@
-Due to security and compliance requirements, this `squdo` session will require approval and monitoring from another engineer. When finished, this session will be archived permanently for later retrieval and analysis.
+Due to security and compliance requirements, this `sudo` session will require approval and monitoring from another engineer. When finished, this session will be archived permanently for later retrieval and analysis.
 
 To continue, another engineer must run:
 


### PR DESCRIPTION
Assuming this is a typo. Can be closed if I'm mistaken!