### PR TITLE
Use _ instead of -

### DIFF
--- a/contrib/sudo_pair.spec
+++ b/contrib/sudo_pair.spec
@@ -1,4 +1,4 @@
-Name: sudo-pair
+Name: sudo_pair
 Version: 0.11.1
 Release: 1
 Summary: Plugin for sudo that requires another human to approve and monitor privileged sudo sessions.


### PR DESCRIPTION
As suggested in #21, let's use `sudo_pair` and not `sudo-pair` everywhere.