### PR TITLE
Include the target README.md as a temporary fix for the spec

### DIFF
--- a/contrib/sudo_pair.spec
+++ b/contrib/sudo_pair.spec
@@ -35,6 +35,7 @@ rm -rf %{buildroot}
 %files
 /usr/libexec/sudo/libsudo_pair.so
 %doc README.md
+%doc sudo_pair/README.md
 %doc sample/etc/sudo.conf
 %doc sample/etc/sudo.prompt.pair
 %doc sample/etc/sudo.prompt.user


### PR DESCRIPTION
I'm just including the target README.md file for now, which should fix the symlink-to-nowhere issue. Better would be removing the symlink and replacing it with the actual file, but this works for now.

Closes #82. 

